### PR TITLE
Add docker compose file at the root of the project

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -2,11 +2,12 @@ FROM python:3-slim
 
 WORKDIR /code
 
-COPY ./resources/. /code/resources/
 RUN apt-get update && apt-get install -y git
+
+COPY ./resources ./resources
+
 RUN pip install --no-cache-dir --upgrade -r /code/resources/requirements.txt
-RUN pip install "fastapi[standard]"
-COPY ./cache /code/cache
-COPY ./api /code/api
+
+COPY . .
 
 CMD ["fastapi", "run", "api/main.py", "--port", "80"]

--- a/Backend/resources/requirements.txt
+++ b/Backend/resources/requirements.txt
@@ -1,5 +1,5 @@
-fastapi
+fastapi[standard]
 typing
 tinydb
-    
+
 resources/PyDriller_Cedric_Version-2.6-py3-none-any.whl

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 Dans le cadre de LOG795 – Projet de fin d’étude
 
+## Quick start using Docker
+Make sure you have docker installed on your machine: https://docs.docker.com/engine/install/
+
+1. Clone the repo locally
+2. Run `docker compose up`
+
+This will start both the backend and frontend services.
+
+Visit http://localhost:8080/
+
 ## Séparation
 
 La séparation des fichiers est claire, backend, frontend et documentation

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,11 @@
+services:
+  backend:
+    build: ./Backend/.
+    volumes:
+      - ./Backend:/code
+    ports:
+      - "80:80"
+  frontend:
+    build: ./Frontend/.
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
Fixes: #2 

I updated the Dockerfile of the backend service, and I added a docker compose file at the root of the project so that both services can be started at the same time with a simple command. I also updated the README at the root of the project to provide instructions.

### Update Backend Dockerfile
Reorder Dockerfile instructions to make build time faster when only the
source changes.

### Add docker compose file at the root of the project
Developers can just run this command at the root of the project to
launch both the frontend and backend services:
```
$ docker compose up
```