### PR TITLE
[Backend] Add Repository model & controller

### DIFF
--- a/api/app/controllers/repositories_controller.rb
+++ b/api/app/controllers/repositories_controller.rb
@@ -1,0 +1,11 @@
+class RepositoriesController < ApplicationController
+  def show
+    repository = Repository.find_by(id: params[:id])
+
+    if repository
+      render(json: repository)
+    else
+      render(json: nil, status: :not_found)
+    end
+  end
+end

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -1,0 +1,2 @@
+class Repository < ApplicationRecord
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -5,6 +5,5 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  get "/repositories/:id", to: "repositories#show"
 end

--- a/api/db/migrate/20241004015517_create_repositories.rb
+++ b/api/db/migrate/20241004015517_create_repositories.rb
@@ -1,0 +1,10 @@
+class CreateRepositories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :repositories do |t|
+      t.string :name
+      t.string :domain
+      t.string :path
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2024_10_04_015517) do
+  create_table "repositories", force: :cascade do |t|
+    t.string "name"
+    t.string "domain"
+    t.string "path"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/api/test/controllers/repositories_controller_test.rb
+++ b/api/test/controllers/repositories_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class RepositoriesControllerTest < ActionDispatch::IntegrationTest
+  test "returns 404 when the repository does not exists" do
+    get "/repositories/9999999999"
+    assert_response(:not_found)
+  end
+
+  test "returns 200 when the repository exists" do
+    repository = repositories(:rails)
+
+    get "/repositories/#{repository.id}"
+    assert_response(:ok)
+    assert_equal("rails", response.parsed_body[:name])
+    assert_equal("github.com", response.parsed_body[:domain])
+    assert_equal("/rails/rails", response.parsed_body[:path])
+  end
+end

--- a/api/test/fixtures/repositories.yml
+++ b/api/test/fixtures/repositories.yml
@@ -1,0 +1,10 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+rails:
+  name: "rails"
+  domain: "github.com"
+  path: "rails/rails"

--- a/api/test/fixtures/repositories.yml
+++ b/api/test/fixtures/repositories.yml
@@ -7,4 +7,4 @@
 rails:
   name: "rails"
   domain: "github.com"
-  path: "rails/rails"
+  path: "/rails/rails"

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class RepositoryTest < ActiveSupport::TestCase
+end


### PR DESCRIPTION
Add the Repository model, powered by the `repositories` table. 
This table contains the high level information of a repository analyzed by the application.

Add the RepositoryController and a route to the `#show` action
