### PR TITLE
[Backend] Add the #create action in RepositoriesController

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -47,3 +47,4 @@ group :development, :test do
 end
 
 gem "octokit"
+gem "addressable", "~> 2.7"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -299,6 +299,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  addressable (~> 2.7)
   bootsnap
   brakeman
   debug

--- a/api/app/controllers/repositories_controller.rb
+++ b/api/app/controllers/repositories_controller.rb
@@ -8,4 +8,23 @@ class RepositoriesController < ApplicationController
       render(json: nil, status: :not_found)
     end
   end
+
+  def create
+    url = params.permit(:url).fetch(:url)
+
+    repository = Repository.find_by_url(url)
+    return render(json: repository, status: 200) if repository
+
+    remote_repository = GithubService.new.fetch_remote_repository(url)
+    unless remote_repository
+      return render(json: { message: "remote repository does not exists." }, status: 404)
+    end
+
+    repository = Repository.from_remote_repository(remote_repository)
+    if repository.save
+      render(json: repository, status: 201)
+    else
+      render(json: { message: "could not create repository.", errors: repositoy.errors.full_messages }, status: 400)
+    end
+  end
 end

--- a/api/app/models/remote_repository.rb
+++ b/api/app/models/remote_repository.rb
@@ -4,7 +4,20 @@ class RemoteRepository
   #
   def initialize(name:, description:, url:)
     @name = name
-    @descriptoin = description
-    @url = url
+    @description = description
+    @remote_url = url
+    @uri = Addressable::URI.heuristic_parse(url)
+  end
+
+  def name
+    @name
+  end
+
+  def domain
+    @uri.domain
+  end
+
+  def path
+    @uri.path
   end
 end

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -5,4 +5,12 @@ class Repository < ApplicationRecord
 
     find_by(domain: uri.domain, path: uri.path)
   end
+
+  def self.from_remote_repository(remote_repository)
+    new.tap do |repository|
+      repository.name = remote_repository.name
+      repository.domain = remote_repository.domain
+      repository.path = remote_repository.path
+    end
+  end
 end

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -1,2 +1,8 @@
 class Repository < ApplicationRecord
+  def self.find_by_url(url)
+    uri = Addressable::URI.heuristic_parse(url)
+    return nil if uri.domain.nil? || uri.path.nil?
+
+    find_by(domain: uri.domain, path: uri.path)
+  end
 end

--- a/api/app/services/github_service.rb
+++ b/api/app/services/github_service.rb
@@ -14,12 +14,12 @@ class GithubService
 
     repository = @client.repository(uri.path[1..])
 
-    return nil unless repository
-
     RemoteRepository.new(
       name: repository.name,
       description: repository.description,
       url: repository.html_url
     )
+  rescue Octokit::NotFound
+    nil
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   get "/repositories/:id", to: "repositories#show"
+  post "/repositories", to: "repositories#create"
 end

--- a/api/test/controllers/repositories_controller_test.rb
+++ b/api/test/controllers/repositories_controller_test.rb
@@ -1,18 +1,66 @@
 require "test_helper"
+require "minitest/mock"
 
 class RepositoriesControllerTest < ActionDispatch::IntegrationTest
-  test "returns 404 when the repository does not exists" do
+  test "#show returns 404 when the repository does not exists" do
     get "/repositories/9999999999"
+
     assert_response(:not_found)
   end
 
-  test "returns 200 when the repository exists" do
+  test "#show returns 200 when the repository exists" do
     repository = repositories(:rails)
 
     get "/repositories/#{repository.id}"
+
     assert_response(:ok)
     assert_equal("rails", response.parsed_body[:name])
     assert_equal("github.com", response.parsed_body[:domain])
     assert_equal("/rails/rails", response.parsed_body[:path])
+  end
+
+  test "#create returns 200 if the repository already exists" do
+    repository = repositories(:rails)
+
+    params = { url: "https://github.com/rails/rails" }
+    post("/repositories", params: params, as: :json)
+
+    assert_response(:ok)
+    assert_equal(repository.id, response.parsed_body[:id])
+  end
+
+  test "#create returns 404 if the remote repository does not exists" do
+    stub_remote_repository(nil) do
+      params = { url: "https://github.com/example/random-repo-123456789" }
+      post("/repositories", params: params, as: :json)
+
+      assert_response(:not_found)
+    end
+  end
+
+  test "#create returns 201 if the repository is created" do
+    remote_repository = RemoteRepository.new(
+      name: "discourse",
+      description: "A platform for community discussion. Free, open, simple.",
+      url: "https://github.com/discourse/discourse"
+    )
+
+    stub_remote_repository(remote_repository) do
+      params = { url: "https://github.com/discourse/discourse" }
+      post("/repositories", params: params, as: :json)
+
+      assert_response(:created)
+    end
+  end
+
+  private
+
+  def stub_remote_repository(remote_repository)
+    mock = Minitest::Mock.new
+    mock.expect(:fetch_remote_repository, remote_repository, [ String ])
+
+    GithubService.stub(:new, mock) do
+      yield
+    end
   end
 end

--- a/api/test/models/remote_repository_test.rb
+++ b/api/test/models/remote_repository_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class RemoteRepositoryTest < ActiveSupport::TestCase
+  def setup
+    @remote_repository = RemoteRepository.new(
+      name: "discourse",
+      description: "A platform for community discussion. Free, open, simple.",
+      url: "https://github.com/discourse/discourse"
+    )
+  end
+
+  test "#name" do
+    assert_equal("discourse", @remote_repository.name)
+  end
+
+  test "#domain" do
+    assert_equal("github.com", @remote_repository.domain)
+  end
+
+  test "#path" do
+    assert_equal("/discourse/discourse", @remote_repository.path)
+  end
+end

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -16,4 +16,19 @@ class RepositoryTest < ActiveSupport::TestCase
   test ".find_by_url returns a repository even when the scheme is missing" do
     assert_equal(repositories(:rails), Repository.find_by_url("github.com/rails/rails"))
   end
+
+  test ".from_remote_repository builds a new repository from a RemoteRepository" do
+    remote_repository = RemoteRepository.new(
+      name: "discourse",
+      description: "A platform for community discussion. Free, open, simple.",
+      url: "https://github.com/discourse/discourse"
+    )
+
+    repository = Repository.from_remote_repository(remote_repository)
+    assert(repository.new_record?)
+    assert_not(repository.persisted?)
+    assert_equal("discourse", repository.name)
+    assert_equal("github.com", repository.domain)
+    assert_equal("/discourse/discourse", repository.path)
+  end
 end

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -1,4 +1,19 @@
 require "test_helper"
 
 class RepositoryTest < ActiveSupport::TestCase
+  test ".find_by_url returns nil when the url is not valid" do
+    assert_nil(Repository.find_by_url("garbage url"))
+  end
+
+  test ".find_by_url returns nil if no repositories matches the url" do
+    assert_nil(Repository.find_by_url("https://github.com/example/repository"))
+  end
+
+  test ".find_by_url returns a repository that matches the url" do
+    assert_equal(repositories(:rails), Repository.find_by_url("https://github.com/rails/rails"))
+  end
+
+  test ".find_by_url returns a repository even when the scheme is missing" do
+    assert_equal(repositories(:rails), Repository.find_by_url("github.com/rails/rails"))
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/visevol/GihubVisualisation/issues/9

Add #create action to RepositoriesController

The create action responds to: `POST /repositories`, and it expects a
url parameter.

The action will verify that the repository exists on the remote, and if
it does, it will create an entry for this repository in our database.