### PR TITLE
[Backend] Add GitRepository lib class

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -48,3 +48,4 @@ end
 
 gem "octokit"
 gem "addressable", "~> 2.7"
+gem "git"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -134,6 +134,11 @@ GEM
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
+    git (2.3.0)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 1.1)
+      rchardet (~> 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -195,6 +200,7 @@ GEM
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
+    process_executer (1.1.2)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -219,6 +225,7 @@ GEM
       nokogiri (~> 1.14)
     rainbow (3.1.1)
     rake (13.2.1)
+    rchardet (1.8.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -303,6 +310,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  git
   kamal
   octokit
   puma (>= 5.0)

--- a/api/lib/git_repository.rb
+++ b/api/lib/git_repository.rb
@@ -1,0 +1,68 @@
+class GitRepository
+  def initialize(remote_url)
+    @remote_url = remote_url
+  end
+
+  def clone
+    Git.clone(@remote_url, temp_directory)
+  end
+
+  #
+  # Calls `git log` on the repository.
+  # Yields an enumerator of lines on the output.
+  #
+  # Example:
+  #
+  #   repo = GitRepository.new("https://github.com/rails/rails")
+  #   repo.clone
+  #   repo.logs do |logs|
+  #     logs.each do |line|
+  #       print(line)
+  #     end
+  #   end
+  #
+  #   output:
+  #     > " create mode 100644 railties/generators/templates/model.erb\n"
+  #     > " create mode 100644 railties/generators/templates/model_test.erb\n"
+  #     > " create mode 100644 railties/helpers/abstract_application.rb\n"
+  #     > " create mode 100644 railties/helpers/application_helper.rb\n"
+  #     > " create mode 100644 railties/helpers/test_helper.rb\n"
+  #     > " create mode 100644 railties/html/404.html\n"
+  #     > " create mode 100644 railties/html/500.html\n"
+  #     > " create mode 100644 railties/html/index.html\n"
+  #     > " create mode 100644 railties/lib/code_statistics.rb\n"
+  #
+  # ==== Options
+  # since:  only show commits more recent than that date (DateTime)
+  # before: only show commits older than that date (DateTime)
+  # format: pretty print format for commits.
+  #         This is passed directly to the `--pretty=format:"#{format}"` option
+  #         See `man git log` for documentation about available formats.
+  #
+  def logs(since: nil, before: nil, format: nil)
+    return unless block_given?
+
+    command = ["log"]
+    command << "--numstat"
+    command << "--summary"
+    command << "--since=#{since.strftime("%Y-%m-%d")}" if since
+    command << "--until=#{before.strftime("%Y-%m-%d")}" if before
+    command << "--pretty=format:#{format}" if format
+
+    Tempfile.create(binmode: true) do |f|
+      cli.run(*command, out: f, err: STDERR, chdir: temp_directory, normalize: true, chomp: true, merge: false)
+      f.rewind
+      yield f.each_line
+    end
+  end
+
+  private
+
+  def temp_directory
+    @temp_directory ||= Dir.mktmpdir
+  end
+
+  def cli
+    @cli ||= Git::CommandLine.new({}, "/usr/bin/git", [], Logger.new(STDOUT))
+  end
+end


### PR DESCRIPTION
Part of: https://github.com/visevol/GihubVisualisation/issues/10

Add the GitRepository class in the lib directory.

This is a wrapper over the process of cloning and extracting logs from a
git repository.

## How to test locally
1. Build the `api` docker container: `docker compose build api`
2. Open a rails command line: `docker compose run api bin/rails c`
3. From this console, you can instantiate the GitRepository class of this PR and play with it:
```ruby
repo = GitRepository.new("https://github.com/rails/rails")
repo.clone
repo.logs do |logs|
  logs.each do |line|
    p line
  end
end
```

^ This clones the https://github.com/rails/rails repository, and dumps the content of all its commits (93 000). 