### PR TITLE
[Backend] Add basic repository data model 

### DIFF
--- a/api/app/models/commit.rb
+++ b/api/app/models/commit.rb
@@ -1,0 +1,7 @@
+class Commit < ApplicationRecord
+  belongs_to :repository
+
+  validates :commit_hash,
+    presence: true,
+    uniqueness: { scope: :repository_id }
+end

--- a/api/app/models/commit.rb
+++ b/api/app/models/commit.rb
@@ -1,5 +1,6 @@
 class Commit < ApplicationRecord
   belongs_to :repository
+  has_many :commit_file_changes
 
   validates :commit_hash,
     presence: true,

--- a/api/app/models/commit_file_change.rb
+++ b/api/app/models/commit_file_change.rb
@@ -1,0 +1,3 @@
+class CommitFileChange < ApplicationRecord
+  belongs_to :commit
+end

--- a/api/db/migrate/20241006232458_create_commits.rb
+++ b/api/db/migrate/20241006232458_create_commits.rb
@@ -1,0 +1,13 @@
+class CreateCommits < ActiveRecord::Migration[8.0]
+  def change
+    create_table :commits do |t|
+      t.references :repository, index: false
+      t.string :commit_hash
+      t.string :author
+      t.datetime :committer_date
+      t.datetime :author_date
+
+      t.index([ :repository_id, :commit_hash ], unique: true)
+    end
+  end
+end

--- a/api/db/migrate/20241007003949_create_commit_file_changes.rb
+++ b/api/db/migrate/20241007003949_create_commit_file_changes.rb
@@ -1,0 +1,10 @@
+class CreateCommitFileChanges < ActiveRecord::Migration[8.0]
+  def change
+    create_table :commit_file_changes do |t|
+      t.references :commit
+      t.string :filepath
+      t.integer :additions, default: 0
+      t.integer :deletions, default: 0
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_04_015517) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_07_003949) do
+  create_table "commit_file_changes", force: :cascade do |t|
+    t.integer "commit_id"
+    t.string "filepath"
+    t.integer "additions", default: 0
+    t.integer "deletions", default: 0
+    t.index ["commit_id"], name: "index_commit_file_changes_on_commit_id"
+  end
+
+  create_table "commits", force: :cascade do |t|
+    t.integer "repository_id"
+    t.string "commit_hash"
+    t.string "author"
+    t.datetime "committer_date"
+    t.datetime "author_date"
+    t.index ["repository_id", "commit_hash"], name: "index_commits_on_repository_id_and_commit_hash", unique: true
+  end
+
   create_table "repositories", force: :cascade do |t|
     t.string "name"
     t.string "domain"

--- a/api/test/fixtures/commit_file_changes.yml
+++ b/api/test/fixtures/commit_file_changes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+rails_4ad93b_Gemfile:
+  commit: rails_4ad93b
+  filepath: Gemfile
+  additions: 1
+  deletions: 1

--- a/api/test/fixtures/commits.yml
+++ b/api/test/fixtures/commits.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+rails_4ad93b:
+  repository: rails
+  commit_hash: 4ad93b56ae27582947c9e37f15f1fc54ea263e26
+  author: David Heinemeier Hansson
+  committer_date: 2024-10-02
+  author_date: 2024-10-02
+
+moodle_52c0da:
+  repository: moodle
+  commit_hash: 52c0da7c647bd6ba8c5f61882d88959821a1fb41
+  author: Jun Pataleta
+  committer_date: 2024-10-05
+  author_date: 2024-10-05

--- a/api/test/fixtures/repositories.yml
+++ b/api/test/fixtures/repositories.yml
@@ -8,3 +8,8 @@ rails:
   name: "rails"
   domain: "github.com"
   path: "/rails/rails"
+
+moodle:
+  name: "moodle"
+  domain: "github.com"
+  path: "/moodle/moodle"

--- a/api/test/models/commit_file_change_test.rb
+++ b/api/test/models/commit_file_change_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class CommitFileChangeTest < ActiveSupport::TestCase
+end

--- a/api/test/models/commit_test.rb
+++ b/api/test/models/commit_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class CommitTest < ActiveSupport::TestCase
+  test "commit_hash is required" do
+    commit = commits(:rails_4ad93b)
+    commit.commit_hash = ""
+
+    assert_not(commit.valid?)
+    assert_equal([ "can't be blank" ], commit.errors[:commit_hash])
+  end
+
+  test "cannot have two commit with the same hash in the same repository" do
+    duplicated_commit = commits(:rails_4ad93b).dup
+    duplicated_commit.save
+
+    assert_not(duplicated_commit.valid?)
+    assert_equal([ "has already been taken" ], duplicated_commit.errors[:commit_hash])
+  end
+
+  test "two commits can have the same hash accross repositories" do
+    original_commit = commits(:rails_4ad93b)
+
+    commit = original_commit.dup
+    commit.repository = repositories(:moodle)
+    commit.save
+
+    assert(commit.valid?)
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/visevol/GihubVisualisation/issues/19

This PR adds two new models: 
- Commit
- CommitFileChange

![image](https://github.com/user-attachments/assets/43c77ef4-9358-4c23-9fd0-a5250a88681e)

