### PR TITLE
[Backend] Add RepositorySyncService

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -49,3 +49,4 @@ end
 gem "octokit"
 gem "addressable", "~> 2.7"
 gem "git"
+gem "mocha"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.1)
+    mocha (2.4.5)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
     net-http (0.4.1)
       uri
@@ -260,6 +262,7 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -312,6 +315,7 @@ DEPENDENCIES
   debug
   git
   kamal
+  mocha
   octokit
   puma (>= 5.0)
   rails!

--- a/api/app/models/commit.rb
+++ b/api/app/models/commit.rb
@@ -1,6 +1,6 @@
 class Commit < ApplicationRecord
   belongs_to :repository
-  has_many :commit_file_changes
+  has_many :file_changes, class_name: "CommitFileChange"
 
   validates :commit_hash,
     presence: true,

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -13,4 +13,12 @@ class Repository < ApplicationRecord
       repository.path = remote_repository.path
     end
   end
+
+  def remote_url
+    Addressable::URI.new.tap do |u|
+      u.host = self.domain
+      u.path = self.path
+      u.scheme = "https"
+    end.to_s
+  end
 end

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -1,4 +1,6 @@
 class Repository < ApplicationRecord
+  has_many :commits
+
   def self.find_by_url(url)
     uri = Addressable::URI.heuristic_parse(url)
     return nil if uri.domain.nil? || uri.path.nil?

--- a/api/app/services/repository_sync_service.rb
+++ b/api/app/services/repository_sync_service.rb
@@ -1,0 +1,49 @@
+class RepositorySyncService
+  def initialize(repository)
+    @repository = repository
+  end
+
+  def index
+    git_repo = GitRepository.new(@repository.remote_url)
+    git_repo.clone
+    git_repo.logs(format: "||%H||%aN||%cs||%as||") do |logs|
+      commit_id = nil
+
+      logs.each do |line|
+        line.force_encoding("utf-8")
+
+        next if line == ""
+
+        if line[0] == "|"
+          result = Commit.insert(commit_data_from_line(line))
+          commit_id = result.first["id"]
+        elsif Integer(line[0], exception: false)
+          CommitFileChange.insert(commit_file_change_data_from_line(line, commit_id))
+        end
+      end
+    end
+  end
+
+  private
+
+  def commit_data_from_line(line)
+    _, hash, author, committer_date, author_date = line.split("||")
+    {
+      repository_id: @repository.id,
+      commit_hash: hash,
+      author: author,
+      committer_date: DateTime.parse(committer_date),
+      author_date: DateTime.parse(author_date)
+    }
+  end
+
+  def commit_file_change_data_from_line(line, commit_id)
+    additions, deletions, filepath = line.split("\t", 3)
+    {
+      commit_id: commit_id,
+      filepath: filepath.strip,
+      additions: additions,
+      deletions: deletions
+    }
+  end
+end

--- a/api/test/fixtures/repositories.yml
+++ b/api/test/fixtures/repositories.yml
@@ -13,3 +13,8 @@ moodle:
   name: "moodle"
   domain: "github.com"
   path: "/moodle/moodle"
+
+example_repository:
+  name: "example"
+  domain: "github.com"
+  path: "/example/example"

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -31,4 +31,8 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_equal("github.com", repository.domain)
     assert_equal("/discourse/discourse", repository.path)
   end
+
+  test "#remote_url" do
+    assert_equal("https://github.com/rails/rails", repositories(:rails).remote_url)
+  end
 end

--- a/api/test/services/repository_sync_service_test.rb
+++ b/api/test/services/repository_sync_service_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class RepositorySyncServiceTest < ActiveSupport::TestCase
+  def setup
+    @repository = repositories(:example_repository)
+  end
+
+  test "#index creates commits for the given repository" do
+    stub_git_repository_logs do
+      <<~GIT_LOGS
+        ||3ecab153fab78e61290892881e9a34d0df6fb7a0||Jonathan Lalande||2024-10-10||2024-10-10||
+        3	0	README.md
+
+        ||71c23127bf7bad405dd3e8e29f9394140882898c||Jonathan Lalande||2024-10-06||2024-10-06||
+        2	0	README.md
+         create mode 100644 README.md
+      GIT_LOGS
+    end
+
+    RepositorySyncService.new(@repository).index
+
+    commit_a = @repository.commits.find_by(commit_hash: "71c23127bf7bad405dd3e8e29f9394140882898c")
+    assert_equal("Jonathan Lalande", commit_a.author)
+    assert_equal(DateTime.parse("2024-10-06"), commit_a.committer_date.to_datetime)
+    assert_equal(DateTime.parse("2024-10-06"), commit_a.author_date.to_datetime)
+
+    commit_b = @repository.commits.find_by(commit_hash: "3ecab153fab78e61290892881e9a34d0df6fb7a0")
+    assert_equal("Jonathan Lalande", commit_b.author)
+    assert_equal(DateTime.parse("2024-10-10"), commit_b.committer_date.to_datetime)
+    assert_equal(DateTime.parse("2024-10-10"), commit_b.author_date.to_datetime)
+  end
+
+  test "#index creates commit_file_changes for each commits" do
+    stub_git_repository_logs do
+      <<~GIT_LOGS
+        ||c8ab6fe877522729d4088dc7bce64b560d56a324||Jonathan Lalande||2024-10-07||2024-10-07
+        21	0	LICENSE
+        0	3	README.md
+        1	0	main.rb
+         create mode 100644 LICENSE
+         create mode 100644 main.rb
+
+        ||3ecab153fab78e61290892881e9a34d0df6fb7a0||Jonathan Lalande||2024-10-06||2024-10-06
+        3	0	README.md
+      GIT_LOGS
+    end
+
+    RepositorySyncService.new(@repository).index
+
+    commit = @repository.commits.find_by(commit_hash: "3ecab153fab78e61290892881e9a34d0df6fb7a0")
+    change = commit.file_changes.find_by(filepath: "README.md")
+    assert_equal("README.md", change.filepath)
+    assert_equal(3, change.additions)
+    assert_equal(0, change.deletions)
+
+    commit = @repository.commits.find_by(commit_hash: "c8ab6fe877522729d4088dc7bce64b560d56a324")
+    change = commit.file_changes.find_by(filepath: "LICENSE")
+    assert_equal("LICENSE", change.filepath)
+    assert_equal(21, change.additions)
+    assert_equal(0, change.deletions)
+
+    change = commit.file_changes.find_by(filepath: "README.md")
+    assert_equal("README.md", change.filepath)
+    assert_equal(0, change.additions)
+    assert_equal(3, change.deletions)
+
+    change = commit.file_changes.find_by(filepath: "main.rb")
+    assert_equal("main.rb", change.filepath)
+    assert_equal(1, change.additions)
+    assert_equal(0, change.deletions)
+  end
+
+  private
+
+  def stub_git_repository_logs(&block)
+    logs_enumerator = (block.call).lines.each
+
+    GitRepository.any_instance.expects(:clone).returns(nil)
+    GitRepository.any_instance
+      .expects(:logs)
+      .with(format: "||%H||%aN||%cs||%as||")
+      .yields(logs_enumerator)
+      .once
+  end
+end

--- a/api/test/test_helper.rb
+++ b/api/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "mocha/minitest"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
Add the RepositorySyncService class

This class takes a `Repository` model, and sync its content in our database:
1. It clones the repository in a tmp directory
2. It calls `git log` on it, and saves the output in a temporary file.
3. The service read the log files and creates `Commit` and `CommitFileChange` records for each of the commits. 