### PR TITLE
[Backend] Improve RepositorySyncService performances

### DIFF
--- a/api/app/services/repository_sync_service.rb
+++ b/api/app/services/repository_sync_service.rb
@@ -1,13 +1,17 @@
 class RepositorySyncService
+  COMMIT_BATCH_SIZE = 2500
+
   def initialize(repository)
     @repository = repository
+    @commits = []
+    @file_changes = []
   end
 
   def index
     git_repo = GitRepository.new(@repository.remote_url)
     git_repo.clone
     git_repo.logs(format: "||%H||%aN||%cs||%as||") do |logs|
-      commit_id = nil
+      current_commit_hash = nil
 
       logs.each do |line|
         line.force_encoding("utf-8")
@@ -15,16 +19,41 @@ class RepositorySyncService
         next if line == ""
 
         if line[0] == "|"
-          result = Commit.insert(commit_data_from_line(line))
-          commit_id = result.first["id"]
+          persist_current_batch if @commits.size >= COMMIT_BATCH_SIZE
+
+          commit = commit_data_from_line(line)
+          current_commit_hash = commit[:commit_hash]
+          @commits << commit
         elsif Integer(line[0], exception: false)
-          CommitFileChange.insert(commit_file_change_data_from_line(line, commit_id))
+          change = commit_file_change_data_from_line(line, current_commit_hash)
+          @file_changes << change
         end
       end
+
+      persist_current_batch
     end
   end
 
   private
+
+  def persist_current_batch
+    Commit.insert_all(@commits)
+
+    commits_by_hash = Commit
+      .select(:id, :commit_hash)
+      .where(repository: @repository, commit_hash: @commits.map { _1[:commit_hash] })
+      .index_by(&:commit_hash)
+
+    @file_changes.each do |change|
+      commit_hash = change.delete(:commit_hash)
+      change[:commit_id] = commits_by_hash[commit_hash].id
+    end
+
+    CommitFileChange.insert_all(@file_changes)
+
+    @commits = []
+    @file_changes = []
+  end
 
   def commit_data_from_line(line)
     _, hash, author, committer_date, author_date = line.split("||")
@@ -37,10 +66,10 @@ class RepositorySyncService
     }
   end
 
-  def commit_file_change_data_from_line(line, commit_id)
+  def commit_file_change_data_from_line(line, commit_hash)
     additions, deletions, filepath = line.split("\t", 3)
     {
-      commit_id: commit_id,
+      commit_hash: commit_hash,
       filepath: filepath.strip,
       additions: additions,
       deletions: deletions

--- a/api/lib/tasks/repositories.rake
+++ b/api/lib/tasks/repositories.rake
@@ -1,4 +1,4 @@
-require 'benchmark'
+require "benchmark"
 
 namespace :repositories do
   desc <<~DESCRIPTION


### PR DESCRIPTION
Improve `RepositorySyncService` performance

Change how `RepositorySyncService` writes to the database. Instead of
writing on each iteration, we instead write in batch.

We're accumulating 2500 commits in memory, then we insert all of them in
one `INSERT` call.

---

### Benchmark
To compare the current code, with the one on this branch we'll compare how long it takes to fully index a large repository like `https://github.com/rails/rails` in our app. 

To do this, you need a repository in your database. 
You can do this via the [rails console](https://guides.rubyonrails.org/command_line.html). 

Once in the console, create a Repository:
```ruby
Repository.create(name: "rails", domain: "github.com", path: "/rails/rails")
=>
#<Repository:0x00007faf5110c978
 id: 2,
 name: "rails",
 domain: "github.com",
 path: "/rails/rails",
 created_at: "2024-10-09 02:12:14.005812000 +0000",
 updated_at: "2024-10-09 02:12:14.005812000 +0000">
```

Then, run the sync benchmarking task. Make sure the `REPOSITORY_ID` is the id of the repository you just created.
```
time REPOSITORY_ID=2 bin/rake repositories:benchmark_sync
```

This task:
- Deletes all commits and file changes in the database for this repository. This allows us to be able to re-run this task multiple time for the same repository.
- Clones the repository
- Imports all its commits and file changes in the database.  
- Outputs a summary of the import and the time it took.

On the `main` branch, the task took `3 minute`: 
![write_benchmark_main](https://github.com/user-attachments/assets/edb9d558-497a-42b0-a184-01eedfe48571)


On this branch, the task took `33 seconds`:
![write_benchmark_optimized](https://github.com/user-attachments/assets/7d515d40-09c3-40c3-9111-a12289e1e632)
