### PR TITLE
[Backend] Enqueue a `RepositorySyncJob` on Repository creation

### DIFF
--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -1,6 +1,8 @@
 class Repository < ApplicationRecord
   has_many :commits
 
+  after_create_commit { RepositorySyncJob.perform_later(repository_id: id) }
+
   def self.find_by_url(url)
     uri = Addressable::URI.heuristic_parse(url)
     return nil if uri.domain.nil? || uri.path.nil?

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RepositoryTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test ".find_by_url returns nil when the url is not valid" do
     assert_nil(Repository.find_by_url("garbage url"))
   end
@@ -34,5 +36,10 @@ class RepositoryTest < ActiveSupport::TestCase
 
   test "#remote_url" do
     assert_equal("https://github.com/rails/rails", repositories(:rails).remote_url)
+  end
+
+  test "enqueues a RepositorySyncJob after creation" do
+    repository = Repository.create(name: "moodle", domain: "github.com", path: "/moodle/moodle")
+    assert_enqueued_with(job: RepositorySyncJob, args: [ { repository_id: repository.id } ])
   end
 end


### PR DESCRIPTION
Closes: https://github.com/visevol/GihubVisualisation/issues/13

Whenever a Repository is created, a RepositorySyncJob is automatically enqueued.