### PR TITLE
[Backend] Prevent creation of duplicated repositories on the same domain

### DIFF
--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -3,6 +3,11 @@ class Repository < ApplicationRecord
 
   after_create_commit { RepositorySyncJob.perform_later(repository_id: id) }
 
+  validates :path, uniqueness: {
+    scope: :domain,
+    message: ->(object, _) { "#{object.remote_url} already exists." }
+  }
+
   def self.find_by_url(url)
     uri = Addressable::URI.heuristic_parse(url)
     return nil if uri.domain.nil? || uri.path.nil?

--- a/api/db/migrate/20241011035221_add_unique_index_on_repository_domain_and_path.rb
+++ b/api/db/migrate/20241011035221_add_unique_index_on_repository_domain_and_path.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnRepositoryDomainAndPath < ActiveRecord::Migration[8.0]
+  def change
+    add_index :repositories, [ :domain, :path ], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_07_003949) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_11_035221) do
   create_table "commit_file_changes", force: :cascade do |t|
     t.integer "commit_id"
     t.string "filepath"
@@ -34,5 +34,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_07_003949) do
     t.string "path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["domain", "path"], name: "index_repositories_on_domain_and_path", unique: true
   end
 end

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -39,7 +39,20 @@ class RepositoryTest < ActiveSupport::TestCase
   end
 
   test "enqueues a RepositorySyncJob after creation" do
-    repository = Repository.create(name: "moodle", domain: "github.com", path: "/moodle/moodle")
+    repository = Repository.create(name: "react", domain: "github.com", path: "/facebook/react")
     assert_enqueued_with(job: RepositorySyncJob, args: [ { repository_id: repository.id } ])
+  end
+
+  test "prevents creation of duplicated repositories on the same domain" do
+    repository = Repository.create(name: "rails", domain: "github.com", path: "/rails/rails")
+    assert_not(repository.valid?)
+    assert(repository.errors.of_kind?(:path, :taken))
+  end
+
+  test "does not prevent the creation of duplicated repositories on different domains" do
+    assert_nothing_raised do
+      Repository.create!(name: "duplicated_repo", domain: "github.com", path: "/example/duplicated_repository")
+      Repository.create!(name: "duplicated_repo", domain: "gitlab.com", path: "/example/duplicated_repository")
+    end
   end
 end


### PR DESCRIPTION
Closes: https://github.com/visevol/GihubVisualisation/issues/16

This PR adds a validation that prevents the creation of duplicated `Repository` on the same domain. 

For example:
```ruby
# not allowed ❌
Repository.create!(name: "duplicated_repo", domain: "github.com", path: "/example/duplicated_repository")
Repository.create!(name: "duplicated_repo", domain: "github.com", path: "/example/duplicated_repository")

# allowed ✅
Repository.create!(name: "duplicated_repo", domain: "github.com", path: "/example/duplicated_repository")
Repository.create!(name: "duplicated_repo", domain: "gitlab.com", path: "/example/duplicated_repository")

``` 