### PR TITLE
[Backend] Connect the `source_files` table with `source_file_changes` 

### DIFF
--- a/api/app/models/commit.rb
+++ b/api/app/models/commit.rb
@@ -1,6 +1,7 @@
 class Commit < ApplicationRecord
   belongs_to :repository
   has_many :source_file_changes
+  has_many :source_files, through: :source_file_changes
 
   validates :commit_hash,
     presence: true,

--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -1,5 +1,7 @@
 class SourceFile < ApplicationRecord
   belongs_to :repository
+  has_many :source_file_changes
+  has_many :commits, through: :source_file_changes
 
   validates :filepath, uniqueness: { scope: :repository_id }
 end

--- a/api/app/models/source_file_change.rb
+++ b/api/app/models/source_file_change.rb
@@ -1,3 +1,4 @@
 class SourceFileChange < ApplicationRecord
   belongs_to :commit
+  belongs_to :source_file
 end

--- a/api/app/services/repository_sync_service.rb
+++ b/api/app/services/repository_sync_service.rb
@@ -4,7 +4,7 @@ class RepositorySyncService
   def initialize(repository)
     @repository = repository
     @commits = []
-    @file_changes = []
+    @files = {}
   end
 
   def index
@@ -25,7 +25,10 @@ class RepositorySyncService
           current_commit_hash = commit[:commit_hash]
           @commits << commit
         elsif Integer(line[0], exception: false)
-          @file_changes << commit_file_change_data_from_line(line, current_commit_hash)
+          change = commit_file_change_data_from_line(line, current_commit_hash)
+          filepath = change.delete(:filepath)
+
+          (@files[filepath] ||= []) << change
         end
       end
 
@@ -37,21 +40,39 @@ class RepositorySyncService
 
   def persist_current_batch
     Commit.insert_all(@commits)
+    SourceFile.insert_all(@files.keys.map { |filepath| source_file_attribute(filepath) })
 
     commits_by_hash = Commit
       .select(:id, :commit_hash)
       .where(repository: @repository, commit_hash: @commits.map { _1[:commit_hash] })
       .index_by(&:commit_hash)
 
-    @file_changes.each do |change|
-      commit_hash = change.delete(:commit_hash)
-      change[:commit_id] = commits_by_hash[commit_hash].id
+    source_files_by_filepath = SourceFile
+      .where(repository: @repository, filepath: @files.keys)
+      .index_by(&:filepath)
+
+    @files.each do |filepath, changes|
+      changes.map! do |change|
+        commit = commits_by_hash[change[:commit_hash]]
+        source_file = source_files_by_filepath[filepath]
+
+        {
+          commit_id: commit.id,
+          source_file_id: source_file.id,
+          additions: change[:additions],
+          deletions: change[:deletions]
+        }
+      end
     end
 
-    SourceFileChange.insert_all(@file_changes)
+    SourceFileChange.insert_all(@files.values.flatten)
 
     @commits = []
-    @file_changes = []
+    @files = {}
+  end
+
+  def source_file_attribute(filepath)
+    { repository_id: @repository.id, filepath: filepath }
   end
 
   def commit_data_from_line(line)

--- a/api/db/migrate/20241013004144_add_association_between_source_files_and_source_file_changes.rb
+++ b/api/db/migrate/20241013004144_add_association_between_source_files_and_source_file_changes.rb
@@ -1,0 +1,6 @@
+class AddAssociationBetweenSourceFilesAndSourceFileChanges < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :source_file_changes, :filepath, :string
+    add_reference :source_file_changes, :source_file
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_13_002642) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_13_004144) do
   create_table "commits", force: :cascade do |t|
     t.integer "repository_id"
     t.string "commit_hash"
@@ -31,10 +31,11 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_13_002642) do
 
   create_table "source_file_changes", force: :cascade do |t|
     t.integer "commit_id"
-    t.string "filepath"
+    t.integer "source_file_id"
     t.integer "additions", default: 0
     t.integer "deletions", default: 0
     t.index ["commit_id"], name: "index_source_file_changes_on_commit_id"
+    t.index ["source_file_id"], name: "index_source_file_changes_on_source_file_id"
   end
 
   create_table "source_files", force: :cascade do |t|

--- a/api/lib/tasks/repositories.rake
+++ b/api/lib/tasks/repositories.rake
@@ -17,11 +17,12 @@ namespace :repositories do
     repository = Repository.find(repository_id)
 
     puts "deleting commits and file changes of repository: #{repository.remote_url}..."
-    CommitFileChange
+    SourceFileChange
       .joins(commit: :repository)
       .where(commit: { repository_id: repository.id })
       .delete_all
-    Commit.where(repository_id: repository.id).delete_all
+    repository.commits.delete_all
+    repository.source_files.delete_all
     puts "done."
 
     puts "syncing #{repository.remote_url}..."
@@ -29,15 +30,15 @@ namespace :repositories do
       RepositorySyncService.new(repository).index
     end
 
-    file_changes_count = CommitFileChange
+    source_file_changes = SourceFileChange
       .joins(commit: :repository)
       .where(commit: { repository_id: repository.id })
-      .count
 
     puts <<~RESULTS
       Sync duration: #{time.to_s.strip}
       Commit created: #{repository.commits.count}
-      File changes created: #{file_changes_count}
+      File created: #{repository.source_files.count}
+      File changes created: #{source_file_changes.count}
     RESULTS
   end
 end

--- a/api/test/fixtures/source_file_changes.yml
+++ b/api/test/fixtures/source_file_changes.yml
@@ -6,6 +6,6 @@
 #
 rails_4ad93b_Gemfile:
   commit: rails_4ad93b
-  filepath: Gemfile
+  source_file: rails_gemfile
   additions: 1
   deletions: 1

--- a/api/test/services/repository_sync_service_test.rb
+++ b/api/test/services/repository_sync_service_test.rb
@@ -48,24 +48,20 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
     RepositorySyncService.new(@repository).index
 
     commit = @repository.commits.find_by(commit_hash: "3ecab153fab78e61290892881e9a34d0df6fb7a0")
-    change = commit.source_file_changes.find_by(filepath: "README.md")
-    assert_equal("README.md", change.filepath)
+    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "README.md" })
     assert_equal(3, change.additions)
     assert_equal(0, change.deletions)
 
     commit = @repository.commits.find_by(commit_hash: "c8ab6fe877522729d4088dc7bce64b560d56a324")
-    change = commit.source_file_changes.find_by(filepath: "LICENSE")
-    assert_equal("LICENSE", change.filepath)
+    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "LICENSE" })
     assert_equal(21, change.additions)
     assert_equal(0, change.deletions)
 
-    change = commit.source_file_changes.find_by(filepath: "README.md")
-    assert_equal("README.md", change.filepath)
+    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "README.md" })
     assert_equal(0, change.additions)
     assert_equal(3, change.deletions)
 
-    change = commit.source_file_changes.find_by(filepath: "main.rb")
-    assert_equal("main.rb", change.filepath)
+    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "main.rb" })
     assert_equal(1, change.additions)
     assert_equal(0, change.deletions)
   end


### PR DESCRIPTION
Closes: https://github.com/visevol/GihubVisualisation/issues/29

Connect the `source_files` table with `source_file_changes`. With this change, `source_file_changes` is now a join table between commits and source files.

Add new associations so expressions like these are possible:
```ruby
repository = Repository.find_by(name: "rails")

initial_commit = repository.commits.first
initial_commit.source_files.count # number of files affected by the initial commit
=> 295

gemfile = repository.source_files.find_by(filepath: "Gemfile")
gemfile.commits.count # number of commits that modifies the Gemfile
=> 879
```