### PR TITLE
[PROTOTYPE] Implement line count for source files

### DIFF
--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -5,10 +5,34 @@ class SourceFile < ApplicationRecord
 
   validates :filepath, uniqueness: { scope: :repository_id }
 
-  def file_size
-    source_file_changes
-      .joins(:commit)
-      .where(commit: { for_file_size: true })
-      .pluck(Arel.sql('SUM(additions - deletions)'))
+  def line_count(hash: nil)
+    if hash
+      # I know this is vulnerable to sql injections, i'm just messing around.
+      # file = 534283
+      # repository = 1
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        SELECT *
+        FROM source_file_changes
+        INNER JOIN commits AS pin ON pin.repository_id = #{repository_id} AND pin.commit_hash = '#{hash}'
+        INNER JOIN commits ON TRUE
+          AND commits.id = source_file_changes.commit_id
+          AND commits.id < pin.id
+          AND commits.for_file_size = 1
+        LIMIT 10
+      SQL
+      # source_file_changes
+        # .joins(:commit)
+        # .joins(<<~JOIN)
+          # INNER JOIN commits as commit_filters ON TRUE
+            # AND commit_filters.commit_hash = '#{hash}'
+            # AND commit_filters.id > commit.id
+        # JOIN
+        # .where(commit: { for_file_size: true })
+    else
+      source_file_changes
+        .joins(:commit)
+        .where(commit: { for_file_size: true })
+        .pluck(Arel.sql('SUM(additions - deletions)'))
+    end
   end
 end

--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -4,4 +4,11 @@ class SourceFile < ApplicationRecord
   has_many :commits, through: :source_file_changes
 
   validates :filepath, uniqueness: { scope: :repository_id }
+
+  def file_size
+    source_file_changes
+      .joins(:commit)
+      .where(commit: { for_file_size: true })
+      .pluck(Arel.sql('SUM(additions - deletions)'))
+  end
 end

--- a/api/db/migrate/20241013072657_add_file_size_columns.rb
+++ b/api/db/migrate/20241013072657_add_file_size_columns.rb
@@ -1,0 +1,7 @@
+class AddFileSizeColumns < ActiveRecord::Migration[8.0]
+  def change
+    add_column :commits, :for_file_size, :boolean, default: false
+
+    add_index :source_file_changes, [:commit_id, :source_file_id], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_13_004144) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_13_072657) do
   create_table "commits", force: :cascade do |t|
     t.integer "repository_id"
     t.string "commit_hash"
     t.string "author"
     t.datetime "committer_date"
     t.datetime "author_date"
+    t.boolean "for_file_size", default: false
     t.index ["repository_id", "commit_hash"], name: "index_commits_on_repository_id_and_commit_hash", unique: true
   end
 
@@ -31,9 +32,10 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_13_004144) do
 
   create_table "source_file_changes", force: :cascade do |t|
     t.integer "commit_id"
-    t.integer "source_file_id"
     t.integer "additions", default: 0
     t.integer "deletions", default: 0
+    t.integer "source_file_id"
+    t.index ["commit_id", "source_file_id"], name: "index_source_file_changes_on_commit_id_and_source_file_id", unique: true
     t.index ["commit_id"], name: "index_source_file_changes_on_commit_id"
     t.index ["source_file_id"], name: "index_source_file_changes_on_source_file_id"
   end

--- a/api/lib/git_repository.rb
+++ b/api/lib/git_repository.rb
@@ -39,13 +39,21 @@ class GitRepository
   #         This is passed directly to the `--pretty=format:"#{format}"` option
   #         See `man git log` for documentation about available formats.
   #
-  def logs(since: nil, before: nil, format: nil)
+  def logs(
+    with_first_parent: false,
+    since: nil,
+    before: nil,
+    format: nil
+  )
     return unless block_given?
 
     command = [ "log" ]
     command << "--reverse"
     command << "--numstat"
     command << "--summary"
+    command << "--no-renames"
+    command << "-m" if with_first_parent
+    command << "--first-parent" if with_first_parent
     command << "--since=#{since.strftime("%Y-%m-%d")}" if since
     command << "--until=#{before.strftime("%Y-%m-%d")}" if before
     command << "--pretty=format:#{format}" if format

--- a/api/query.sql
+++ b/api/query.sql
@@ -1,0 +1,11 @@
+SELECT source_files.filepath, SUM(additions - deletions) as line_count
+FROM source_file_changes
+INNER JOIN source_files ON source_files.id = source_file_changes.source_file_id
+INNER JOIN commits AS pin ON pin.repository_id = 1 AND pin.commit_hash = 'd82f73ecabe71fc3814eff0bd26f4f431f690266'
+INNER JOIN commits ON TRUE
+  AND commits.id = source_file_changes.commit_id
+  AND commits.id <= pin.id
+  AND commits.for_file_size = 1
+  AND commits.repository_id = 1
+GROUP BY source_files.id
+HAVING line_count > 0


### PR DESCRIPTION
This is some shit code, but it works. It solves https://github.com/visevol/GihubVisualisation/issues/34

Given a file, I wanna know the line count of this file. 
By default, I want the line count of the file on HEAD.
I also wants to be able to get the line count at a given revision.

- The `#line_count` method on SourceFile returns the line count of the file at HEAD.
- The `query.sql` shows a query we can run to dump the line count of files, at a given revision.