### PR TITLE
[Backend] Add uniqueness constraint on SourceFileChange

### DIFF
--- a/api/app/models/source_file_change.rb
+++ b/api/app/models/source_file_change.rb
@@ -1,4 +1,6 @@
 class SourceFileChange < ApplicationRecord
   belongs_to :commit
   belongs_to :source_file
+
+  validates :source_file, uniqueness: { scope: :commit_id }
 end

--- a/api/db/migrate/20241013193116_add_unique_index_on_source_file_change.rb
+++ b/api/db/migrate/20241013193116_add_unique_index_on_source_file_change.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnSourceFileChange < ActiveRecord::Migration[8.0]
+  def change
+    add_index :source_file_changes, [ :source_file_id, :commit_id ], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_13_004144) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_13_193116) do
   create_table "commits", force: :cascade do |t|
     t.integer "repository_id"
     t.string "commit_hash"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_13_004144) do
     t.integer "additions", default: 0
     t.integer "deletions", default: 0
     t.index ["commit_id"], name: "index_source_file_changes_on_commit_id"
+    t.index ["source_file_id", "commit_id"], name: "index_source_file_changes_on_source_file_id_and_commit_id", unique: true
     t.index ["source_file_id"], name: "index_source_file_changes_on_source_file_id"
   end
 

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -10,3 +10,4 @@
 #
 Repository.find_or_create_by!(name: "rails", domain: "github.com", path: "/rails/rails")
 Repository.find_or_create_by!(name: "discourse", domain: "github.com", path: "/discourse/discourse")
+Repository.find_or_create_by!(name: "venomq", domain: "github.com", path: "/zergov/venomq")

--- a/api/test/models/source_file_change_test.rb
+++ b/api/test/models/source_file_change_test.rb
@@ -1,4 +1,9 @@
 require "test_helper"
 
 class SourceFileChangeTest < ActiveSupport::TestCase
+  test "cannot have 2 changes for a file on the same commit" do
+    duplicated_change = source_file_changes(:rails_4ad93b_Gemfile).dup
+    assert_not(duplicated_change.valid?)
+    assert(duplicated_change.errors.of_kind?(:source_file, :taken))
+  end
 end


### PR DESCRIPTION
A commit can only change a file in one way.

For example, It does not make sense to say:
  - Commit "abcdef" changes file A by adding 2 lines
  - Commit "abcdef" changes file A by adding 5 lines
Instead, we say:
  - Commit "abcdef" changes file A by adding 7 lines

This prevents recording multiple source file changes for the same file
on a given commit.