### PR TITLE
[Backend] Tag commits if they are part of the `changes ledger`

### DIFF
--- a/api/app/models/source_file_change.rb
+++ b/api/app/models/source_file_change.rb
@@ -3,4 +3,6 @@ class SourceFileChange < ApplicationRecord
   belongs_to :source_file
 
   validates :source_file, uniqueness: { scope: :commit_id }
+
+  scope :for_filepath, ->(filepath) { joins(:source_file).find_by(source_file: { filepath: filepath }) }
 end

--- a/api/db/migrate/20241013222300_add_for_changes_ledger_to_commits.rb
+++ b/api/db/migrate/20241013222300_add_for_changes_ledger_to_commits.rb
@@ -1,0 +1,5 @@
+class AddForChangesLedgerToCommits < ActiveRecord::Migration[8.0]
+  def change
+    add_column :commits, :for_changes_ledger, :boolean, default: false
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_13_193116) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_13_222300) do
   create_table "commits", force: :cascade do |t|
     t.integer "repository_id"
     t.string "commit_hash"
     t.string "author"
     t.datetime "committer_date"
     t.datetime "author_date"
+    t.boolean "for_changes_ledger", default: false
     t.index ["repository_id", "commit_hash"], name: "index_commits_on_repository_id_and_commit_hash", unique: true
   end
 

--- a/api/lib/git_repository.rb
+++ b/api/lib/git_repository.rb
@@ -58,8 +58,11 @@ class GitRepository
   # format: pretty print format for commits.
   #         This is passed directly to the `--pretty=format:"#{format}"` option
   #         See `man git log` for documentation about available formats.
+  # first_parent: Shows the history including change diffs, but only from the “main branch”
+  #               perspective, skipping commits that come from merged branches, and showing full
+  #               diffs of changes introduced by the merges.
   #
-  def logs(since: nil, before: nil, format: nil)
+  def logs(since: nil, before: nil, format: nil, first_parent: false)
     return unless block_given?
 
     command = [ "log" ]
@@ -69,6 +72,11 @@ class GitRepository
     command << "--since=#{since.strftime("%Y-%m-%d")}" if since
     command << "--until=#{before.strftime("%Y-%m-%d")}" if before
     command << "--pretty=format:#{format}" if format
+
+    if first_parent
+      command << "-m"
+      command << "--first-parent"
+    end
 
     Tempfile.create(binmode: true) do |f|
       cli.run(*command, out: f, err: STDERR, chdir: @directory, normalize: true, chomp: true, merge: false)

--- a/api/test/services/repository_sync_service_test.rb
+++ b/api/test/services/repository_sync_service_test.rb
@@ -66,6 +66,28 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
     assert_equal(0, change.deletions)
   end
 
+  test "#index creates source_files for each file in the log" do
+    stub_git_repository_logs do
+      <<~GIT_LOGS
+        ||3ecab153fab78e61290892881e9a34d0df6fb7a0||Jonathan Lalande||2024-10-06||2024-10-06
+        3	0	README.md
+
+        ||c8ab6fe877522729d4088dc7bce64b560d56a324||Jonathan Lalande||2024-10-07||2024-10-07
+        21	0	LICENSE
+        0	3	README.md
+        1	0	main.rb
+         create mode 100644 LICENSE
+         create mode 100644 main.rb
+      GIT_LOGS
+    end
+
+    RepositorySyncService.new(@repository).index
+
+    assert_not_nil(@repository.source_files.find_by(filepath: "README.md"))
+    assert_not_nil(@repository.source_files.find_by(filepath: "LICENSE"))
+    assert_not_nil(@repository.source_files.find_by(filepath: "main.rb"))
+  end
+
   private
 
   def stub_git_repository_logs(&block)

--- a/api/test/services/repository_sync_service_test.rb
+++ b/api/test/services/repository_sync_service_test.rb
@@ -48,20 +48,20 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
     RepositorySyncService.new(@repository).index
 
     commit = @repository.commits.find_by(commit_hash: "3ecab153fab78e61290892881e9a34d0df6fb7a0")
-    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "README.md" })
+    change = commit.source_file_changes.for_filepath("README.md")
     assert_equal(3, change.additions)
     assert_equal(0, change.deletions)
 
     commit = @repository.commits.find_by(commit_hash: "c8ab6fe877522729d4088dc7bce64b560d56a324")
-    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "LICENSE" })
+    change = commit.source_file_changes.for_filepath("LICENSE")
     assert_equal(21, change.additions)
     assert_equal(0, change.deletions)
 
-    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "README.md" })
+    change = commit.source_file_changes.for_filepath("README.md")
     assert_equal(0, change.additions)
     assert_equal(3, change.deletions)
 
-    change = commit.source_file_changes.joins(:source_file).find_by(source_file: { filepath: "main.rb" })
+    change = commit.source_file_changes.for_filepath("main.rb")
     assert_equal(1, change.additions)
     assert_equal(0, change.deletions)
   end

--- a/api/test/services/repository_sync_service_test.rb
+++ b/api/test/services/repository_sync_service_test.rb
@@ -3,10 +3,13 @@ require "test_helper"
 class RepositorySyncServiceTest < ActiveSupport::TestCase
   def setup
     @repository = repositories(:example_repository)
+
+    GitRepository.any_instance.expects(:clone).returns(nil).once
   end
 
   test "#index creates commits for the given repository" do
-    stub_git_repository_logs do
+    stub_git_commit_history_for_line_counts { "" }
+    stub_git_commit_history do
       <<~GIT_LOGS
         ||71c23127bf7bad405dd3e8e29f9394140882898c||Jonathan Lalande||2024-10-06||2024-10-06||
         2	0	README.md
@@ -31,7 +34,8 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
   end
 
   test "#index creates source_file_changes for each commits" do
-    stub_git_repository_logs do
+    stub_git_commit_history_for_line_counts { "" }
+    stub_git_commit_history do
       <<~GIT_LOGS
         ||3ecab153fab78e61290892881e9a34d0df6fb7a0||Jonathan Lalande||2024-10-06||2024-10-06
         3	0	README.md
@@ -67,7 +71,8 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
   end
 
   test "#index creates source_files for each file in the log" do
-    stub_git_repository_logs do
+    stub_git_commit_history_for_line_counts { "" }
+    stub_git_commit_history do
       <<~GIT_LOGS
         ||3ecab153fab78e61290892881e9a34d0df6fb7a0||Jonathan Lalande||2024-10-06||2024-10-06
         3	0	README.md
@@ -88,16 +93,119 @@ class RepositorySyncServiceTest < ActiveSupport::TestCase
     assert_not_nil(@repository.source_files.find_by(filepath: "main.rb"))
   end
 
+  test "#index creates source_file_changes for merge commits" do
+    stub_git_commit_history do
+      # The empty lines here represents merge commits.
+      # `git log --numstat` don't show stats about merge commits.
+      #
+      <<~GIT_LOGS
+        ||fdeba4af9036551e029591e64780a5b5ad6aab98||Ryuta Kamizono||2024-10-13||2024-10-13||
+        ||f942221d4629ce10a259a6adf92eccc559955770||Ryuta Kamizono||2024-10-13||2024-10-13||
+        ||28a8fa54deaf87843cf653a2ce9684b14548c1e6||Yusuke Nakamura||2024-10-13||2024-10-13||
+        6	2	guides/assets/javascripts/guides.js
+
+        ||f9ec1ae62e21a278128a94b46f99a3928dd32f0e||Hartley McGuire||2024-10-12||2024-10-12||
+      GIT_LOGS
+    end
+
+    stub_git_commit_history_for_line_counts do
+      # `git log -m --first-parent --numstat` returns the accurate log of additions / deletions
+      # that sums up to the final state of the repository.
+      #
+      <<~GIT_LOGS
+        ||fdeba4af9036551e029591e64780a5b5ad6aab98||Ryuta Kamizono||2024-10-13||2024-10-13||
+        9	0	activerecord/test/cases/date_time_test.rb
+        4	0	activerecord/test/config.example.yml
+
+        ||f942221d4629ce10a259a6adf92eccc559955770||Ryuta Kamizono||2024-10-13||2024-10-13||
+        6	2	guides/assets/javascripts/guides.js
+
+        ||f9ec1ae62e21a278128a94b46f99a3928dd32f0e||Hartley McGuire||2024-10-12||2024-10-12||
+        1	1	guides/source/getting_started.md
+      GIT_LOGS
+    end
+
+    RepositorySyncService.new(@repository).index
+
+    commit = @repository.commits.find_by(commit_hash: "fdeba4af9036551e029591e64780a5b5ad6aab98")
+    change = commit.source_file_changes.for_filepath("activerecord/test/cases/date_time_test.rb")
+    assert_equal(9, change.additions)
+    assert_equal(0, change.deletions)
+
+    change = commit.source_file_changes.for_filepath("activerecord/test/config.example.yml")
+    assert_equal(4, change.additions)
+    assert_equal(0, change.deletions)
+
+    commit = @repository.commits.find_by(commit_hash: "f942221d4629ce10a259a6adf92eccc559955770")
+    change = commit.source_file_changes.for_filepath("guides/assets/javascripts/guides.js")
+    assert_equal(6, change.additions)
+    assert_equal(2, change.deletions)
+
+    commit = @repository.commits.find_by(commit_hash: "f9ec1ae62e21a278128a94b46f99a3928dd32f0e")
+    change = commit.source_file_changes.for_filepath("guides/source/getting_started.md")
+    assert_equal(1, change.additions)
+    assert_equal(1, change.deletions)
+  end
+
+  test "#index marks commits for changes ledger" do
+    stub_git_commit_history do
+      <<~GIT_LOGS
+        ||f9ec1ae62e21a278128a94b46f99a3928dd32f0e||Hartley McGuire||2024-10-12||2024-10-12||
+        ||28a8fa54deaf87843cf653a2ce9684b14548c1e6||Yusuke Nakamura||2024-10-13||2024-10-13||
+        6	2	guides/assets/javascripts/guides.js
+
+        ||f942221d4629ce10a259a6adf92eccc559955770||Ryuta Kamizono||2024-10-13||2024-10-13||
+        ||fdeba4af9036551e029591e64780a5b5ad6aab98||Ryuta Kamizono||2024-10-13||2024-10-13||
+      GIT_LOGS
+    end
+
+    stub_git_commit_history_for_line_counts do
+      <<~GIT_LOGS
+        ||f9ec1ae62e21a278128a94b46f99a3928dd32f0e||Hartley McGuire||2024-10-12||2024-10-12||
+        1	1	guides/source/getting_started.md
+
+        ||f942221d4629ce10a259a6adf92eccc559955770||Ryuta Kamizono||2024-10-13||2024-10-13||
+        6	2	guides/assets/javascripts/guides.js
+
+        ||fdeba4af9036551e029591e64780a5b5ad6aab98||Ryuta Kamizono||2024-10-13||2024-10-13||
+        9	0	activerecord/test/cases/date_time_test.rb
+        4	0	activerecord/test/config.example.yml
+      GIT_LOGS
+    end
+
+    RepositorySyncService.new(@repository).index
+
+    commits_for_ledger, commits = @repository.commits.order(:id).partition(&:for_changes_ledger)
+    assert_equal([ "28a8fa54deaf87843cf653a2ce9684b14548c1e6" ], commits.map(&:commit_hash))
+    assert_equal(
+      [
+        "f9ec1ae62e21a278128a94b46f99a3928dd32f0e",
+        "f942221d4629ce10a259a6adf92eccc559955770",
+        "fdeba4af9036551e029591e64780a5b5ad6aab98"
+      ],
+      commits_for_ledger.map(&:commit_hash)
+    )
+  end
+
   private
 
-  def stub_git_repository_logs(&block)
+  def stub_git_commit_history(&block)
     logs_enumerator = (block.call).lines.each
 
-    GitRepository.any_instance.expects(:clone).returns(nil)
     GitRepository.any_instance
       .expects(:logs)
       .with(format: "||%H||%aN||%cs||%as||")
       .yields(logs_enumerator)
-      .once
+      .at_least_once
+  end
+
+  def stub_git_commit_history_for_line_counts(&block)
+    logs_enumerator = (block.call).lines.each
+
+    GitRepository.any_instance
+      .expects(:logs)
+      .with(format: "||%H||%aN||%cs||%as||", first_parent: true)
+      .yields(logs_enumerator)
+      .at_least_once
   end
 end


### PR DESCRIPTION
The `changes ledger` is a set of commits in which it's safe to sum their `source_file_changes` to get an accurate representation of the state of the repository at a given revision.

This PR:
- adds a `for_changes_ledger` column on commits.
- update the RepositorySyncService so that it generates the changes ledger on top of the commit history. 
  - commits part of that ledger are tagged by setting their `for_changes_ledger` to `true`.

This new concept allows us to give the `line_count` of a `source_file`, at any revision.   