### PR TITLE
[Backend] Implement the `#line_count` method on `SourceFile` 

### DIFF
--- a/api/app/models/commit.rb
+++ b/api/app/models/commit.rb
@@ -3,6 +3,8 @@ class Commit < ApplicationRecord
   has_many :source_file_changes
   has_many :source_files, through: :source_file_changes
 
+  scope :on_changes_ledger, -> { where(for_changes_ledger: true) }
+
   validates :commit_hash,
     presence: true,
     uniqueness: { scope: :repository_id }

--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -4,4 +4,13 @@ class SourceFile < ApplicationRecord
   has_many :commits, through: :source_file_changes
 
   validates :filepath, uniqueness: { scope: :repository_id }
+
+  def line_count(revision_id: nil)
+    source_file_changes.then do |changes|
+      changes = changes.joins(:commit)
+      changes = changes.merge(Commit.on_changes_ledger)
+      changes = changes.merge(Commit.where(id: ..revision_id)) if revision_id
+      changes.sum_line_changes
+    end
+  end
 end

--- a/api/app/models/source_file_change.rb
+++ b/api/app/models/source_file_change.rb
@@ -5,4 +5,5 @@ class SourceFileChange < ApplicationRecord
   validates :source_file, uniqueness: { scope: :commit_id }
 
   scope :for_filepath, ->(filepath) { joins(:source_file).find_by(source_file: { filepath: filepath }) }
+  scope :sum_line_changes, -> { sum("additions - deletions") }
 end

--- a/api/test/fixtures/commits.yml
+++ b/api/test/fixtures/commits.yml
@@ -17,3 +17,26 @@ moodle_52c0da:
   author: Jun Pataleta
   committer_date: 2024-10-05
   author_date: 2024-10-05
+
+test_repository_6a3e17:
+  repository: test_repository
+  commit_hash: 6a3e1775d43ec3a51c66d7672dcfc6628ea01dcd
+  author: Jonathan Lalande
+  committer_date: 2024-10-13
+  author_date: 2024-10-13
+  for_changes_ledger: true
+
+test_repository_1bd82e:
+  repository: test_repository
+  commit_hash: 1bd82e1b47706d021c419c5c4b0363bc90892039
+  author: Jonathan Lalande
+  committer_date: 2024-10-13
+  author_date: 2024-10-13
+
+test_repository_c7dc1a:
+  repository: test_repository
+  commit_hash: c7dc1aec5968621f63944cf41888d3000bed44fc
+  author: Jonathan Lalande
+  committer_date: 2024-10-13
+  author_date: 2024-10-13
+  for_changes_ledger: true

--- a/api/test/fixtures/repositories.yml
+++ b/api/test/fixtures/repositories.yml
@@ -18,3 +18,8 @@ example_repository:
   name: "example"
   domain: "github.com"
   path: "/example/example"
+
+test_repository:
+  name: "zergov-test-repository"
+  domain: "github.com"
+  path: "/zergov/zergov-test-repository"

--- a/api/test/fixtures/source_file_changes.yml
+++ b/api/test/fixtures/source_file_changes.yml
@@ -9,3 +9,21 @@ rails_4ad93b_Gemfile:
   source_file: rails_gemfile
   additions: 1
   deletions: 1
+
+test_repository_6a3e17_readme:
+  commit: test_repository_6a3e17
+  source_file: test_repository_readme
+  additions: 7
+  deletions: 0
+
+test_repository_1bd82e_main_rb:
+  commit: test_repository_1bd82e
+  source_file: test_repository_main
+  additions: 1
+  deletions: 0
+
+test_repository_c7dc1a_main_rb:
+  commit: test_repository_c7dc1a
+  source_file: test_repository_main
+  additions: 1
+  deletions: 0

--- a/api/test/fixtures/source_files.yml
+++ b/api/test/fixtures/source_files.yml
@@ -7,3 +7,11 @@
 rails_gemfile:
   repository: rails
   filepath: "Gemfile"
+
+test_repository_readme:
+  repository: test_repository
+  filepath: "README.md"
+
+test_repository_main:
+  repository: test_repository
+  filepath: "main.rb"

--- a/api/test/models/source_file_test.rb
+++ b/api/test/models/source_file_test.rb
@@ -6,4 +6,16 @@ class SourceFileTest < ActiveSupport::TestCase
     assert_not(file.valid?)
     assert(file.errors.of_kind?(:filepath, :taken))
   end
+
+  test "#line_count" do
+    assert_equal(7, source_files(:test_repository_readme).line_count)
+    assert_equal(1, source_files(:test_repository_main).line_count)
+  end
+
+  test "#line_count at a specific revision" do
+    revision = commits(:test_repository_6a3e17).id
+
+    assert_equal(7, source_files(:test_repository_readme).line_count(revision_id: revision))
+    assert_equal(0, source_files(:test_repository_main).line_count(revision_id: revision))
+  end
 end


### PR DESCRIPTION
Implement SourceFile#line_count

The #line_count method returns the line count of the file.

The method accepts a `revision_id` kwargs, which is the id of a commit
you're targetting. When provided, the method will output the line count
of the file at that revision.