### PR TITLE
[Backend] Implement a Gitland command that returns the file listing of a repository with the with line count

### DIFF
--- a/api/app/services/gitland/commands/list_tree_with_line_numbers.rb
+++ b/api/app/services/gitland/commands/list_tree_with_line_numbers.rb
@@ -1,21 +1,21 @@
 module Gitland
   module Commands
-    class CommandLsTree < GitCommand
+    class ListTreeWithLineNumbers < GitCommand
+      EMPTY_DIRECTORY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
       #
       # Executes `git ls-tree`
       #
-      def initialize(repository, recursive: false, long: false)
+      def initialize(repository)
         @repository = repository
-        @recursive = recursive
-        @long = long
       end
 
       def execute
         cli = Git::CommandLine.new({}, "/usr/bin/git", [], Logger.new("/dev/null"))
 
-        command = [ "ls-tree" ]
-        command << "-r" if @recursive
-        command << "--long" if @long
+        command = [ "diff" ]
+        command << "--numstat"
+        command << EMPTY_DIRECTORY_TREE_HASH
         command << "HEAD"
 
         output = cli.run(
@@ -29,11 +29,11 @@ module Gitland
         ).stdout
 
         output.lines.map! do |line|
-          _, _, _, size, filepath = line.strip.split
+          line_count, _, filepath = line.strip.split
 
           {
             filepath: filepath,
-            size: size.to_i
+            line_count: line_count.to_i
           }
         end
       end

--- a/api/app/services/gitland/repository.rb
+++ b/api/app/services/gitland/repository.rb
@@ -5,7 +5,7 @@ module Gitland
     end
 
     def list_all_files_with_size
-      Commands::CommandLsTree.new(@repository, recursive: true, long: true).execute
+      Commands::ListTreeWithLineNumbers.new(@repository).execute
     end
   end
 end


### PR DESCRIPTION
Change the LsTree Gitland command so that it list the file tree with the line number of each file, instead of the size of each file.

Apparently, the `4b825dc642cb6eb9a060e54bf8d69288fbee4904` hash represents an empty directory in Git. 
This means we can diff the current repository with this hash to get the diff of line numbers for each file. Because the `4b825dc642cb6eb9a060e54bf8d69288fbee4904` represents an empty directory, by definition the added lines in the diff is the line number of that file.