### PR TITLE
[Backend] Add the trees controller

### DIFF
--- a/api/app/controllers/trees_controller.rb
+++ b/api/app/controllers/trees_controller.rb
@@ -1,0 +1,19 @@
+class TreesController < ApplicationController
+  def show
+    return render_repository_not_found unless repository
+
+    Gitland::Repository.new(repository)
+      .list_all_files_with_size
+      .then { |files| render(json: files) }
+  end
+
+  private
+
+  def repository
+    @repository ||= Repository.find_by(id: params[:repository_id])
+  end
+
+  def render_repository_not_found
+    render(json: [], status: :not_found)
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
 
   get "/repositories/:id", to: "repositories#show"
   post "/repositories", to: "repositories#create"
+
+  get "/repositories/:repository_id/tree/head", to: "trees#show"
 end

--- a/api/test/controllers/trees_controller_test.rb
+++ b/api/test/controllers/trees_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class TreesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @repository = repositories(:rails)
+  end
+
+  test "#show returns 404 when the repository does not exists" do
+    get "/repositories/99999/tree/head"
+
+    assert_response(:not_found)
+  end
+
+  test "#show returns 200 when the repository exists" do
+    files = stub_gitland_repository(:list_all_files_with_size) do
+      [
+        { "filepath" => "Gemfile", "line_count" => 123 },
+        { "filepath" => "actionpack/lib/action_pack.rb", "line_count" => 27 },
+      ]
+    end
+
+    get "/repositories/#{@repository.id}/tree/head"
+    assert_response(:ok)
+    assert_equal(files, response.parsed_body)
+  end
+
+  private
+
+  def stub_gitland_repository(method, &block)
+    return_value = block.call
+    gitland_repo = mock()
+    gitland_repo.stubs(method).returns(return_value)
+
+    Gitland::Repository
+      .expects(:new)
+      .with(@repository)
+      .returns(gitland_repo)
+
+    return_value
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/visevol/GihubVisualisation/issues/42

This controller can be used to find all files on a repository, with their line numbers.

Usage:
```
GET /repositories/3/tree/head
```

returns:
```json
[{"filepath":".formatter.exs","line_count":4},{"filepath":".gitignore","line_count":24},{"filepath":"LICENSE.txt","line_count":21},{"filepath":"README.md","line_count":32},{"filepath":"amqp/amqp-xml-doc0-9-1.pdf","line_count":0},{"filepath":"amqp/amqp0-9-1.pdf","line_count":0},{"filepath":"amqp/amqp0-9-1.stripped.xml","line_count":459},{"filepath":"amqp/amqp0-9-1.xml","line_count":2843},{"filepath":"config/config.exs","line_count":30},{"filepath":"examples/.gitignore","line_count":1},{"filepath":"examples/README.md","line_count":12},{"filepath":"examples/requirements.txt","line_count":1},{"filepath":"examples/tutorial_1_hello_world/receive.py","line_count":18},{"filepath":"examples/tutorial_1_hello_world/send.py","line_count":12},{"filepath":"lib/venomq.ex","line_count":19},{"filepath":"lib/venomq/channel.ex","line_count":152},{"filepath":"lib/venomq/channel_supervisor.ex","line_count":16},{"filepath":"lib/venomq/connection.ex","line_count":137},{"filepath":"lib/venomq/connection_acceptor.ex","line_count":27},{"filepath":"lib/venomq/exchange_direct.ex","line_count":49},{"filepath":"lib/venomq/exchange_supervisor.ex","line_count":27},{"filepath":"lib/venomq/queue.ex","line_count":94},{"filepath":"lib/venomq/queue_supervisor.ex","line_count":51},{"filepath":"lib/venomq/transport/data.ex","line_count":136},{"filepath":"lib/venomq/transport/frame.ex","line_count":58},{"filepath":"lib/venomq/transport/method.ex","line_count":127},{"filepath":"mix.exs","line_count":24},{"filepath":"test/test_helper.exs","line_count":1},{"filepath":"test/transport/data_test.exs","line_count":33}]
```